### PR TITLE
Fix compatibility issues with `package.json` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "install:server": "npm ci && husky install && (cd api && npm ci)",
     "build:client": "cd client && npm run build",
     "build:server": "cd api && npm run build",
-    "prettier:client": "prettier client/src/**/*.{js,ts,jsx,tsx,json} --check --ignore-path client/.gitignore",
-    "lint:client": "eslint client/src/**/*.{js,ts,jsx,tsx,json} --ignore-path client/.gitignore",
-    "format:client": "prettier 'client/src/**/*.{js,ts,jsx,tsx,json}' --write --ignore-path client/.gitignore & eslint 'client/src/**/*.{js,ts,jsx,tsx,json}' --fix --ignore-path client/.gitignore",
-    "prettier:server": "prettier api/src/**/*.{js,ts,json} --check --ignore-path server/.gitignore",
-    "format:server": "prettier api/src/**/*.{js,ts,json} --write --ignore-path server/.gitignore"
+    "prettier:client": "prettier \"client/src/**/*.{js,ts,jsx,tsx,json}\" --check --ignore-path client/.gitignore",
+    "lint:client": "eslint \"client/src/**/*.{js,ts,jsx,tsx,json}\" --ignore-path client/.gitignore",
+    "format:client": "prettier \"client/src/**/*.{js,ts,jsx,tsx,json}\" --write --ignore-path client/.gitignore & eslint \"client/src/**/*.{js,ts,jsx,tsx,json}\" --fix --ignore-path client/.gitignore",
+    "prettier:server": "prettier \"api/src/**/*.{js,ts,json}\" --check --ignore-path server/.gitignore",
+    "format:server": "prettier \"api/src/**/*.{js,ts,json}\" --write --ignore-path server/.gitignore"
   },
   "lint-staged": {
     "client/src/**/*.{js,ts,jsx,tsx,json}": [


### PR DESCRIPTION
## Description
Prettier scripts were not working properly with MacOS, this PR fixes that.

### Type of change
- [ ] Backend (`api/`)
- [ ] Frontend (`client/`)
- [X] General

### Images (FE only)
Remove this section if not working on FE.

### How to test
Short guide on how can the changes be tested if applicable.