### PR TITLE
Client side login and signup

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,6 @@
         "chakra-ui-autocomplete": "^1.4.5",
         "chakra-ui-simple-autocomplete": "^2.3.0",
         "framer-motion": "^6.5.1",
-        "google-map-react": "^2.2.0",
         "lorem-ipsum": "^2.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2071,14 +2070,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -2156,11 +2147,6 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@motionone/animation": {
       "version": "10.15.1",
@@ -4814,11 +4800,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5156,24 +5137,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
-    },
-    "node_modules/google-map-react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.2.0.tgz",
-      "integrity": "sha512-UPiTwR3qNKJJizURXTuCbnBr8kLtLsiikj/KH1UTLGhadnU6fT+CE3CLw1lzZwk5zZIduQQODyIcEwNInECmUg==",
-      "dependencies": {
-        "@googlemaps/js-api-loader": "^1.7.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "eventemitter3": "^4.0.4",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -8597,14 +8560,6 @@
         }
       }
     },
-    "@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -8663,11 +8618,6 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "@motionone/animation": {
       "version": "10.15.1",
@@ -10735,11 +10685,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11011,17 +10956,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
-    },
-    "google-map-react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.2.0.tgz",
-      "integrity": "sha512-UPiTwR3qNKJJizURXTuCbnBr8kLtLsiikj/KH1UTLGhadnU6fT+CE3CLw1lzZwk5zZIduQQODyIcEwNInECmUg==",
-      "requires": {
-        "@googlemaps/js-api-loader": "^1.7.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "eventemitter3": "^4.0.4",
-        "prop-types": "^15.7.2"
-      }
     },
     "gopd": {
       "version": "1.0.1",

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -7,33 +7,59 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  useToast,
   VStack,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
 import { useNavigate } from "react-router-dom";
 
+const API_URL = "http://localhost:4466/api/v1";
+
 const LoginForm = () => {
   const navigate = useNavigate();
+  const toast = useToast();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
 
   const toggleShowPassword = () => setShowPassword(!showPassword);
 
-  const handleSubmit = (e: React.SyntheticEvent) => {
+  const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
-    console.log("email: ", email, "password: ", password);
 
-    // TODO: Send login request to server
-    const response = true;
+    try {
+      const loginRes = await fetch(`${API_URL}/auth/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: email,
+          password: password,
+        }),
+      });
 
-    if (response) {
-      // redirect to home page
+      if (loginRes.status === 401) {
+        throw new Error("Invalid email or password");
+      }
+
       navigate("/");
-    } else {
-      // redirect to login page
-      navigate("/login");
+      toast({
+        title: "Success",
+        description: "You have successfully logged in.",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+      });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Invalid email or password.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
     }
   };
 

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Center,
   FormControl,
   FormLabel,
   Icon,
@@ -12,65 +11,62 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
+import { useNavigate } from "react-router-dom";
 
 const LoginForm = () => {
-  const width = "40%";
-
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
 
   const toggleShowPassword = () => setShowPassword(!showPassword);
 
-  // const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-  //   e.preventDefault();
-  //   try {
-  //     const { data } = await loginUser({
-  //       variables: {
-  //         email,
-  //         password,
-  //       },
-  //     });
-  //     localStorage.setItem("token", data.login.token);
-  //     history.push("/");
-  //   } catch (err) {
-  //     console.log(err);
-  //   }
-  // };
+  const handleSubmit = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    console.log("email: ", email, "password: ", password);
+
+    // TODO: Send login request to server
+    const response = true;
+
+    if (response) {
+      // redirect to home page
+      navigate("/");
+    } else {
+      // redirect to login page
+      navigate("/login");
+    }
+  };
 
   return (
-    // <form onSubmit={handleSubmit}>
-    <VStack as="form" spacing={4} onSubmit={console.log}>
-      <Center w="100%">
-        <FormControl id="username" w={width}>
-          <FormLabel>Email</FormLabel>
+    <VStack as="form" spacing={4} onSubmit={handleSubmit}>
+      <FormControl id="username" isRequired>
+        <FormLabel>Email</FormLabel>
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </FormControl>
+
+      <FormControl id="password" isRequired>
+        <FormLabel>Password</FormLabel>
+        <InputGroup>
           <Input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            type={showPassword ? "text" : "password"}
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
           />
-        </FormControl>
-      </Center>
-      <Center w="100%">
-        <FormControl id="password" w={width}>
-          <FormLabel>Password</FormLabel>
-          <InputGroup>
-            <Input
-              type={showPassword ? "text" : "password"}
-              placeholder="Password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-            <InputRightElement>
-              <IconButton aria-label={"toggle view password"} onClick={toggleShowPassword}>
-                <Icon as={showPassword ? AiOutlineEyeInvisible : AiOutlineEye} />
-              </IconButton>
-            </InputRightElement>
-          </InputGroup>
-        </FormControl>
-      </Center>
-      <Button type="submit" w={width}>
+          <InputRightElement>
+            <IconButton aria-label={"toggle view password"} onClick={toggleShowPassword}>
+              <Icon as={showPassword ? AiOutlineEyeInvisible : AiOutlineEye} />
+            </IconButton>
+          </InputRightElement>
+        </InputGroup>
+      </FormControl>
+
+      <Button type="submit" w="100%">
         Login
       </Button>
     </VStack>

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -14,7 +14,9 @@ import { useState } from "react";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
 import { useNavigate } from "react-router-dom";
 
-const API_URL = "http://localhost:3000/api/v1";
+const API_URL = import.meta.env.DEV
+  ? `http://localhost:${import.meta.env.VITE_SERVER_PORT || 3000}/api/v1`
+  : "";
 
 const LoginForm = () => {
   const navigate = useNavigate();
@@ -41,8 +43,9 @@ const LoginForm = () => {
       });
 
       const json = await loginRes.json();
+      if (import.meta.env.DEV) console.log(json);
 
-      if (loginRes.status === 201) {
+      if (loginRes.ok) {
         navigate("/");
         toast({
           title: "Success",
@@ -61,6 +64,8 @@ const LoginForm = () => {
         });
       }
     } catch (error) {
+      if (import.meta.env.DEV) console.log(error);
+
       toast({
         title: "Error",
         description: "Something went wrong. Please try again.",

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  Center,
+  FormControl,
+  FormLabel,
+  Icon,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  VStack,
+} from "@chakra-ui/react";
+import React, { useState } from "react";
+import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
+
+const LoginForm = () => {
+  const width = "40%";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+
+  const toggleShowPassword = () => setShowPassword(!showPassword);
+
+  // const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  //   e.preventDefault();
+  //   try {
+  //     const { data } = await loginUser({
+  //       variables: {
+  //         email,
+  //         password,
+  //       },
+  //     });
+  //     localStorage.setItem("token", data.login.token);
+  //     history.push("/");
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // };
+
+  return (
+    // <form onSubmit={handleSubmit}>
+    <VStack as="form" spacing={4} onSubmit={console.log}>
+      <Center w="100%">
+        <FormControl id="username" w={width}>
+          <FormLabel>Email</FormLabel>
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </FormControl>
+      </Center>
+      <Center w="100%">
+        <FormControl id="password" w={width}>
+          <FormLabel>Password</FormLabel>
+          <InputGroup>
+            <Input
+              type={showPassword ? "text" : "password"}
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <InputRightElement>
+              <IconButton aria-label={"toggle view password"} onClick={toggleShowPassword}>
+                <Icon as={showPassword ? AiOutlineEyeInvisible : AiOutlineEye} />
+              </IconButton>
+            </InputRightElement>
+          </InputGroup>
+        </FormControl>
+      </Center>
+      <Button type="submit" w={width}>
+        Login
+      </Button>
+    </VStack>
+  );
+};
+
+export default LoginForm;

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -10,11 +10,11 @@ import {
   useToast,
   VStack,
 } from "@chakra-ui/react";
-import React, { useState } from "react";
+import { useState } from "react";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
 import { useNavigate } from "react-router-dom";
 
-const API_URL = "http://localhost:4466/api/v1";
+const API_URL = "http://localhost:3000/api/v1";
 
 const LoginForm = () => {
   const navigate = useNavigate();
@@ -40,22 +40,30 @@ const LoginForm = () => {
         }),
       });
 
-      if (loginRes.status === 401) {
-        throw new Error("Invalid email or password");
-      }
+      const json = await loginRes.json();
 
-      navigate("/");
-      toast({
-        title: "Success",
-        description: "You have successfully logged in.",
-        status: "success",
-        duration: 5000,
-        isClosable: true,
-      });
+      if (loginRes.status === 201) {
+        navigate("/");
+        toast({
+          title: "Success",
+          description: "You have successfully logged in.",
+          status: "success",
+          duration: 10000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: json.message,
+          status: "error",
+          duration: 10000,
+          isClosable: true,
+        });
+      }
     } catch (error) {
       toast({
         title: "Error",
-        description: "Invalid email or password.",
+        description: "Something went wrong. Please try again.",
         status: "error",
         duration: 5000,
         isClosable: true,

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import {
   Input,
@@ -16,6 +16,7 @@ import {
   AlertIcon,
   ListItem,
   UnorderedList,
+  Link,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
@@ -53,28 +54,29 @@ const SignupForm = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     setFormValues((prev) => ({ ...prev, [id]: value }));
-
-    if (id === "password" || id === "confirmPassword") {
-      validatePassword(e);
-      validateConfirmPassword(e);
-    }
   };
 
-  const validatePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!passwordRegex.test(e.target.value)) {
+  const validatePassword = (pass: string) => {
+    if (!passwordRegex.test(pass)) {
       setPasswordError(true);
     } else {
       setPasswordError(false);
     }
   };
 
-  const validateConfirmPassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value !== formValues.password) {
+  const validateConfirmPassword = (pass: string) => {
+    if (pass !== formValues.password) {
       setConfirmPasswordError(true);
     } else {
       setConfirmPasswordError(false);
     }
   };
+
+  // Validate password and confirm password on change
+  useEffect(() => {
+    validatePassword(formValues.password);
+    validateConfirmPassword(formValues.confirmPassword);
+  }, [formValues.password, formValues.confirmPassword]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -83,7 +85,7 @@ const SignupForm = () => {
     // TODO: Add validation
     // TODO: Add API call
 
-    const isAccountCreated = true; // get this from API call
+    const isAccountCreated = false; // get this from API call
 
     if (isAccountCreated) {
       navigate("/");
@@ -95,12 +97,19 @@ const SignupForm = () => {
         isClosable: true,
       });
     } else {
-      navigate("/signup");
       toast({
-        title: "Account not created",
-        description: "There was an error when creating your account.",
+        title: "Account with that email already exists",
+        description: (
+          <Text>
+            An account with that email already exists.
+            <br />
+            <Link href="/login">
+              <Text as="u">Please sign in.</Text>
+            </Link>
+          </Text>
+        ),
         status: "error",
-        duration: 5000,
+        duration: 10000,
         isClosable: true,
       });
     }

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+
+import { Input, FormLabel, FormControl, VStack, Button } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+
+const SignupForm = () => {
+  const navigate = useNavigate();
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log(firstName, lastName, email, password, confirmPassword);
+
+    // TODO: Add validation
+    // TODO: Add API call
+
+    const isAccountCreated = true; // get this from API call
+
+    if (isAccountCreated) {
+      navigate("/");
+    } else {
+      navigate("/signup");
+    }
+  };
+
+  return (
+    <VStack as="form" spacing={4} onSubmit={onSubmit}>
+      <FormControl isRequired>
+        <FormLabel>First Name</FormLabel>
+        <Input
+          type="text"
+          id="firstName"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+        />
+      </FormControl>
+      <FormControl isRequired>
+        <FormLabel>Last Name</FormLabel>
+        <Input
+          type="text"
+          id="lastName"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+        />
+      </FormControl>
+      <FormControl isRequired>
+        <FormLabel>Email</FormLabel>
+        <Input type="email" id="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </FormControl>
+      <FormControl isRequired>
+        <FormLabel>Password</FormLabel>
+        <Input
+          type="password"
+          id="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </FormControl>
+      <FormControl isRequired>
+        <FormLabel>Confirm Password</FormLabel>
+        <Input
+          type="password"
+          id="confirmPassword"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+        />
+      </FormControl>
+      <Button type="submit" w="100%">
+        Create Account
+      </Button>
+    </VStack>
+  );
+};
+
+export default SignupForm;

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -1,20 +1,43 @@
 import React, { useState } from "react";
 
-import { Input, FormLabel, FormControl, VStack, Button, useToast } from "@chakra-ui/react";
+import {
+  Input,
+  FormLabel,
+  FormControl,
+  VStack,
+  Button,
+  useToast,
+  FormErrorMessage,
+} from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
+
+type FormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
 
 const SignupForm = () => {
   const navigate = useNavigate();
   const toast = useToast();
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [formValues, setFormValues] = useState<FormValues>({
+    firstName: "",
+    lastName: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    setFormValues((prev) => ({ ...prev, [id]: value }));
+  };
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log(firstName, lastName, email, password, confirmPassword);
+    console.log(formValues);
 
     // TODO: Add validation
     // TODO: Add API call
@@ -46,42 +69,27 @@ const SignupForm = () => {
     <VStack as="form" spacing={4} onSubmit={onSubmit}>
       <FormControl isRequired>
         <FormLabel>First Name</FormLabel>
-        <Input
-          type="text"
-          id="firstName"
-          value={firstName}
-          onChange={(e) => setFirstName(e.target.value)}
-        />
+        <Input type="text" id="firstName" value={formValues.firstName} onChange={handleChange} />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Last Name</FormLabel>
-        <Input
-          type="text"
-          id="lastName"
-          value={lastName}
-          onChange={(e) => setLastName(e.target.value)}
-        />
+        <Input type="text" id="lastName" value={formValues.lastName} onChange={handleChange} />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Email</FormLabel>
-        <Input type="email" id="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <Input type="email" id="email" value={formValues.email} onChange={handleChange} />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Password</FormLabel>
-        <Input
-          type="password"
-          id="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+        <Input type="password" id="password" value={formValues.password} onChange={handleChange} />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Confirm Password</FormLabel>
         <Input
           type="password"
           id="confirmPassword"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
+          value={formValues.confirmPassword}
+          onChange={handleChange}
         />
       </FormControl>
       <Button type="submit" w="100%">

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -20,6 +20,7 @@ import {
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
+import { createUser, getUserByEmail } from "../../../api/src/api/users/users.services";
 
 type FormValues = {
   firstName: string;
@@ -82,21 +83,11 @@ const SignupForm = () => {
     e.preventDefault();
     console.log(formValues);
 
-    // TODO: Add validation
-    // TODO: Add API call
+    // check if an account with that email already exists
+    const emailExists = getUserByEmail(formValues.email);
+    console.log(emailExists);
 
-    const isAccountCreated = false; // get this from API call
-
-    if (isAccountCreated) {
-      navigate("/");
-      toast({
-        title: "Account created",
-        description: "Your account has been created successfully.",
-        status: "success",
-        duration: 5000,
-        isClosable: true,
-      });
-    } else {
+    if (emailExists != null) {
       toast({
         title: "Account with that email already exists",
         description: (
@@ -112,7 +103,20 @@ const SignupForm = () => {
         duration: 10000,
         isClosable: true,
       });
+      return;
     }
+
+    const user = createUser(formValues.email, formValues.password, formValues.firstName);
+    console.log(user);
+
+    navigate("/");
+    toast({
+      title: "Account created",
+      description: "Your account has been created successfully.",
+      status: "success",
+      duration: 5000,
+      isClosable: true,
+    });
   };
 
   return (

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -8,8 +8,13 @@ import {
   Button,
   useToast,
   FormErrorMessage,
+  InputRightElement,
+  IconButton,
+  Icon,
+  InputGroup,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
+import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
 
 type FormValues = {
   firstName: string;
@@ -22,6 +27,11 @@ type FormValues = {
 const SignupForm = () => {
   const navigate = useNavigate();
   const toast = useToast();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const toggleShowPassword = () => setShowPassword(!showPassword);
+  const toggleShowConfirmPassword = () => setShowConfirmPassword(!showConfirmPassword);
+
   const [formValues, setFormValues] = useState<FormValues>({
     firstName: "",
     lastName: "",
@@ -69,28 +79,65 @@ const SignupForm = () => {
     <VStack as="form" spacing={4} onSubmit={onSubmit}>
       <FormControl isRequired>
         <FormLabel>First Name</FormLabel>
-        <Input type="text" id="firstName" value={formValues.firstName} onChange={handleChange} />
+        <Input
+          type="text"
+          id="firstName"
+          placeholder="John"
+          value={formValues.firstName}
+          onChange={handleChange}
+        />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Last Name</FormLabel>
-        <Input type="text" id="lastName" value={formValues.lastName} onChange={handleChange} />
+        <Input
+          type="text"
+          id="lastName"
+          placeholder="Doe"
+          value={formValues.lastName}
+          onChange={handleChange}
+        />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Email</FormLabel>
-        <Input type="email" id="email" value={formValues.email} onChange={handleChange} />
+        <Input
+          type="email"
+          id="email"
+          placeholder="john@email.com"
+          value={formValues.email}
+          onChange={handleChange}
+        />
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Password</FormLabel>
-        <Input type="password" id="password" value={formValues.password} onChange={handleChange} />
+        <InputGroup>
+          <Input
+            type={showPassword ? "text" : "password"}
+            id="password"
+            value={formValues.password}
+            onChange={handleChange}
+          />
+          <InputRightElement>
+            <IconButton aria-label={"toggle view password"} onClick={toggleShowPassword}>
+              <Icon as={showPassword ? AiOutlineEyeInvisible : AiOutlineEye} />
+            </IconButton>
+          </InputRightElement>
+        </InputGroup>
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Confirm Password</FormLabel>
-        <Input
-          type="password"
-          id="confirmPassword"
-          value={formValues.confirmPassword}
-          onChange={handleChange}
-        />
+        <InputGroup>
+          <Input
+            type={showConfirmPassword ? "text" : "password"}
+            id="confirmPassword"
+            value={formValues.confirmPassword}
+            onChange={handleChange}
+          />
+          <InputRightElement>
+            <IconButton aria-label={"toggle view password"} onClick={toggleShowConfirmPassword}>
+              <Icon as={showConfirmPassword ? AiOutlineEyeInvisible : AiOutlineEye} />
+            </IconButton>
+          </InputRightElement>
+        </InputGroup>
       </FormControl>
       <Button type="submit" w="100%">
         Create Account

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Input,
@@ -16,7 +16,6 @@ import {
   AlertIcon,
   ListItem,
   UnorderedList,
-  Link,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
@@ -29,7 +28,7 @@ type FormValues = {
   confirmPassword: string;
 };
 
-const API_URL = "http://localhost:4466/api/v1";
+const API_URL = "http://localhost:3000/api/v1";
 
 const SignupForm = () => {
   const navigate = useNavigate();
@@ -96,32 +95,34 @@ const SignupForm = () => {
         }),
       });
 
-      if (registerRes.status === 400) {
-        throw new Error("Account with that email already exists");
-      }
+      const json = await registerRes.json();
 
-      navigate("/");
-      toast({
-        title: "Account created",
-        description: "Your account has been created successfully.",
-        status: "success",
-        duration: 5000,
-        isClosable: true,
-      });
+      if (registerRes.status === 201) {
+        navigate("/");
+        toast({
+          title: "Account created",
+          description: "Your account has been created successfully.",
+          status: "success",
+          duration: 10000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: "Error",
+          description: json.message,
+          status: "error",
+          duration: 10000,
+          isClosable: true,
+        });
+      }
     } catch (error) {
+      console.log(error);
+
       toast({
-        title: "Account with that email already exists",
-        description: (
-          <Text>
-            An account with that email already exists.
-            <br />
-            <Link href="/login">
-              <Text as="u">Please sign in.</Text>
-            </Link>
-          </Text>
-        ),
+        title: "Error",
+        description: "Something went wrong. Please try again.",
         status: "error",
-        duration: 10000,
+        duration: 5000,
         isClosable: true,
       });
     }

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -7,11 +7,15 @@ import {
   VStack,
   Button,
   useToast,
-  FormErrorMessage,
   InputRightElement,
   IconButton,
   Icon,
   InputGroup,
+  Text,
+  Alert,
+  AlertIcon,
+  ListItem,
+  UnorderedList,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
@@ -27,10 +31,16 @@ type FormValues = {
 const SignupForm = () => {
   const navigate = useNavigate();
   const toast = useToast();
+
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   const toggleShowPassword = () => setShowPassword(!showPassword);
   const toggleShowConfirmPassword = () => setShowConfirmPassword(!showConfirmPassword);
+
+  const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()\-_=+{};:,<.>/?]).{6,}$/;
+  const [passwordError, setPasswordError] = useState(false);
+  const [confirmPasswordError, setConfirmPasswordError] = useState(false);
 
   const [formValues, setFormValues] = useState<FormValues>({
     firstName: "",
@@ -43,9 +53,30 @@ const SignupForm = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     setFormValues((prev) => ({ ...prev, [id]: value }));
+
+    if (id === "password" || id === "confirmPassword") {
+      validatePassword(e);
+      validateConfirmPassword(e);
+    }
   };
 
-  const onSubmit = (e: React.FormEvent) => {
+  const validatePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!passwordRegex.test(e.target.value)) {
+      setPasswordError(true);
+    } else {
+      setPasswordError(false);
+    }
+  };
+
+  const validateConfirmPassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value !== formValues.password) {
+      setConfirmPasswordError(true);
+    } else {
+      setConfirmPasswordError(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     console.log(formValues);
 
@@ -76,7 +107,7 @@ const SignupForm = () => {
   };
 
   return (
-    <VStack as="form" spacing={4} onSubmit={onSubmit}>
+    <VStack as="form" spacing={4} onSubmit={handleSubmit}>
       <FormControl isRequired>
         <FormLabel>First Name</FormLabel>
         <Input
@@ -122,6 +153,19 @@ const SignupForm = () => {
             </IconButton>
           </InputRightElement>
         </InputGroup>
+        <Alert status="error" borderRadius={10} my={3} display={passwordError ? "flex" : "none"}>
+          <AlertIcon />
+          <VStack spacing={2}>
+            <Text>Your password must satisfy the following requirements:</Text>
+            <UnorderedList w="80%">
+              <ListItem>At least 6 characters long</ListItem>
+              <ListItem>At least 1 uppercase letter</ListItem>
+              <ListItem>At least 1 lowercase letter</ListItem>
+              <ListItem>At least 1 special character</ListItem>
+              <ListItem>At least 1 number</ListItem>
+            </UnorderedList>
+          </VStack>
+        </Alert>
       </FormControl>
       <FormControl isRequired>
         <FormLabel>Confirm Password</FormLabel>
@@ -139,7 +183,25 @@ const SignupForm = () => {
           </InputRightElement>
         </InputGroup>
       </FormControl>
-      <Button type="submit" w="100%">
+      <Alert
+        status="error"
+        borderRadius={10}
+        my={3}
+        display={confirmPasswordError ? "flex" : "none"}
+      >
+        <AlertIcon />
+        <Text>Your passwords must match.</Text>
+      </Alert>
+      <Button
+        type="submit"
+        w="100%"
+        disabled={
+          passwordError ||
+          confirmPasswordError ||
+          formValues.password == "" ||
+          formValues.confirmPassword == ""
+        }
+      >
         Create Account
       </Button>
     </VStack>

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 
-import { Input, FormLabel, FormControl, VStack, Button } from "@chakra-ui/react";
+import { Input, FormLabel, FormControl, VStack, Button, useToast } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 
 const SignupForm = () => {
   const navigate = useNavigate();
+  const toast = useToast();
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
@@ -22,8 +23,22 @@ const SignupForm = () => {
 
     if (isAccountCreated) {
       navigate("/");
+      toast({
+        title: "Account created",
+        description: "Your account has been created successfully.",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+      });
     } else {
       navigate("/signup");
+      toast({
+        title: "Account not created",
+        description: "There was an error when creating your account.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
     }
   };
 

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -83,9 +83,10 @@ const SignupForm = () => {
     e.preventDefault();
     console.log(formValues);
 
-    // check if an account with that email already exists
-    const emailExists = getUserByEmail(formValues.email);
-    console.log(emailExists);
+    // check if an account with that email already exists)
+    const emailExists = fetch(`http://localhost:4466/api/v1/users/email/${formValues.email}`)
+      .then((res) => res.json())
+      .then((data) => console.log(data));
 
     if (emailExists != null) {
       toast({
@@ -106,8 +107,15 @@ const SignupForm = () => {
       return;
     }
 
-    const user = createUser(formValues.email, formValues.password, formValues.firstName);
-    console.log(user);
+    const user = fetch("http://localhost:4466/api/v1/users/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(formValues),
+    })
+      .then((res) => res.json())
+      .then((data) => console.log(data));
 
     navigate("/");
     toast({

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -28,7 +28,9 @@ type FormValues = {
   confirmPassword: string;
 };
 
-const API_URL = "http://localhost:3000/api/v1";
+const API_URL = import.meta.env.DEV
+  ? `http://localhost:${import.meta.env.VITE_SERVER_PORT || 3000}/api/v1`
+  : "";
 
 const SignupForm = () => {
   const navigate = useNavigate();
@@ -96,8 +98,9 @@ const SignupForm = () => {
       });
 
       const json = await registerRes.json();
+      if (import.meta.env.DEV) console.log(json);
 
-      if (registerRes.status === 201) {
+      if (registerRes.ok) {
         navigate("/");
         toast({
           title: "Account created",
@@ -116,7 +119,7 @@ const SignupForm = () => {
         });
       }
     } catch (error) {
-      console.log(error);
+      if (import.meta.env.DEV) console.log(error);
 
       toast({
         title: "Error",

--- a/client/src/components/SignupForm.tsx
+++ b/client/src/components/SignupForm.tsx
@@ -20,7 +20,6 @@ import {
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineEyeInvisible, AiOutlineEye } from "react-icons/ai";
-import { createUser, getUserByEmail } from "../../../api/src/api/users/users.services";
 
 type FormValues = {
   firstName: string;
@@ -29,6 +28,8 @@ type FormValues = {
   password: string;
   confirmPassword: string;
 };
+
+const API_URL = "http://localhost:4466/api/v1";
 
 const SignupForm = () => {
   const navigate = useNavigate();
@@ -79,16 +80,35 @@ const SignupForm = () => {
     validateConfirmPassword(formValues.confirmPassword);
   }, [formValues.password, formValues.confirmPassword]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log(formValues);
 
-    // check if an account with that email already exists)
-    const emailExists = fetch(`http://localhost:4466/api/v1/users/email/${formValues.email}`)
-      .then((res) => res.json())
-      .then((data) => console.log(data));
+    try {
+      const registerRes = await fetch(`${API_URL}/auth/register`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: formValues.email,
+          password: formValues.password,
+          displayName: `${formValues.firstName} ${formValues.lastName}`,
+        }),
+      });
 
-    if (emailExists != null) {
+      if (registerRes.status === 400) {
+        throw new Error("Account with that email already exists");
+      }
+
+      navigate("/");
+      toast({
+        title: "Account created",
+        description: "Your account has been created successfully.",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+      });
+    } catch (error) {
       toast({
         title: "Account with that email already exists",
         description: (
@@ -104,27 +124,7 @@ const SignupForm = () => {
         duration: 10000,
         isClosable: true,
       });
-      return;
     }
-
-    const user = fetch("http://localhost:4466/api/v1/users/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(formValues),
-    })
-      .then((res) => res.json())
-      .then((data) => console.log(data));
-
-    navigate("/");
-    toast({
-      title: "Account created",
-      description: "Your account has been created successfully.",
-      status: "success",
-      duration: 5000,
-      isClosable: true,
-    });
   };
 
   return (

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import theme from "styles/theme";
-import { BasePage, Home, Property, Login } from "pages";
+import { BasePage, Home, Property, Login, Signup } from "pages";
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);
@@ -17,6 +17,7 @@ root.render(
           <Route path="/" element={<Home />} />
           <Route path="/property" element={<Property />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
         </Routes>
       </BasePage>
     </BrowserRouter>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import theme from "styles/theme";
-import { BasePage, Home, Property } from "pages";
+import { BasePage, Home, Property, Login } from "pages";
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);
@@ -16,6 +16,7 @@ root.render(
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/property" element={<Property />} />
+          <Route path="/login" element={<Login />} />
         </Routes>
       </BasePage>
     </BrowserRouter>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,14 @@
+import LoginForm from "components/LoginForm";
+
+import { Heading } from "@chakra-ui/react";
+
+const Login = () => {
+  return (
+    <>
+      <Heading>Login</Heading>
+      <LoginForm />
+    </>
+  );
+};
+
+export default Login;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,13 +1,17 @@
 import LoginForm from "components/LoginForm";
 
-import { Heading } from "@chakra-ui/react";
+import { Box, Heading, Link, Text } from "@chakra-ui/react";
 
 const Login = () => {
   return (
-    <>
-      <Heading>Login</Heading>
+    <Box w="40%" mx="auto">
+      <Heading mb="20px">Login</Heading>
       <LoginForm />
-    </>
+
+      <Link href="/signup" display="block" mt="50px">
+        <Text as="u">Don&apos;t have an account? Sign up</Text>
+      </Link>
+    </Box>
   );
 };
 

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -4,9 +4,9 @@ import SignupForm from "components/SignupForm";
 
 const Signup = () => {
   return (
-    <Box w="40%" mx="auto">
-      <Heading mb="20px">Signup</Heading>
-      <Link href="/login" display="block" mb="20px">
+    <Box w="40%" mx="auto" mb="30px">
+      <Heading>Signup</Heading>
+      <Link href="/login" display="block" my="30px">
         <Text as="u">Already have an account? Sign in</Text>
       </Link>
       <SignupForm />

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -1,0 +1,17 @@
+import { Box, Heading, Link, Text } from "@chakra-ui/react";
+
+import SignupForm from "components/SignupForm";
+
+const Signup = () => {
+  return (
+    <Box w="40%" mx="auto">
+      <Heading mb="20px">Signup</Heading>
+      <SignupForm />
+      <Link href="/login" display="block" mt="50px">
+        <Text as="u">Already have an account? Sign in</Text>
+      </Link>
+    </Box>
+  );
+};
+
+export default Signup;

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -6,10 +6,10 @@ const Signup = () => {
   return (
     <Box w="40%" mx="auto">
       <Heading mb="20px">Signup</Heading>
-      <SignupForm />
-      <Link href="/login" display="block" mt="50px">
+      <Link href="/login" display="block" mb="20px">
         <Text as="u">Already have an account? Sign in</Text>
       </Link>
+      <SignupForm />
     </Box>
   );
 };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import BasePage from "./BasePage";
 import Home from "./UserHome";
 import Property from "./Property";
+import Login from "./Login";
 
-export { BasePage, Home, Property };
+export { BasePage, Home, Property, Login };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,5 +2,6 @@ import BasePage from "./BasePage";
 import Home from "./UserHome";
 import Property from "./Property";
 import Login from "./Login";
+import Signup from "./Signup";
 
-export { BasePage, Home, Property, Login };
+export { BasePage, Home, Property, Login, Signup };

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src/**/*"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Description
Added pages for user login and new user signup
Called Auth APIs for the respective pages
Once the user successfully registers/logs in, they are directed to the homepage

### Type of change
- [ ] Backend (`api/`)
- [x] Frontend (`client/`)
- [ ] General

### Images (FE only)
Login
![Screenshot 2023-03-18 at 3 48 55 PM](https://user-images.githubusercontent.com/92836735/226144044-b797e58e-2578-463b-84bc-d09ad04387b8.png)

Sign Up
![Screenshot 2023-03-18 at 3 51 16 PM](https://user-images.githubusercontent.com/92836735/226144182-7ef00906-9d24-4c08-a973-c0778fa36f64.png)

Failing Password verification and strength check
![Screenshot 2023-03-18 at 3 52 37 PM](https://user-images.githubusercontent.com/92836735/226144234-e698b937-7d5c-4886-a57e-e6379fc5e6a5.png)

Passing Password verification and strength check
![Screenshot 2023-03-18 at 3 53 51 PM](https://user-images.githubusercontent.com/92836735/226144265-825ee929-7997-465f-a97f-37b3ca66575d.png)

### How to test

To test login:
- Test Email: `email@example.com`
- Test Password: `Password*1`
- try other emails and passwords

To test signup:
- enter any info
- try above email and password as it is an existing user
