### PR TITLE
api: Update post visibility logic

### DIFF
--- a/api/src/api/post/post.services.ts
+++ b/api/src/api/post/post.services.ts
@@ -85,9 +85,12 @@ const updatePost = async (
 };
 
 const deletePost = async (postId: string) => {
-  const del = await prismaClient.post.delete({
+  const del = await prismaClient.post.update({
     where: {
       id: postId,
+    },
+    data: {
+      published: false,
     },
   });
   return del;
@@ -116,11 +119,17 @@ const getPost = async (postId: string) => {
       },
     },
   });
+
+  if (post && !post.published) return null;
+
   return post;
 };
 
 const getAllPosts = async () => {
   const posts = await prismaClient.post.findMany({
+    where: {
+      published: true,
+    },
     include: {
       author: {
         select: {
@@ -137,6 +146,9 @@ const getAllPosts = async () => {
           },
         },
       },
+    },
+    orderBy: {
+      createdAt: "desc",
     },
   });
   return posts;


### PR DESCRIPTION
## Description
- Posts is now hidden from API results if their `published` field is set to `false`.
- Post deletion logic changed to updating `published` field to `false`.

### Type of change
- [X] Backend (`api/`)
- [ ] Frontend (`client/`)
- [ ] General

### Images (FE only)
Remove this section if not working on FE.

### How to test
Short guide on how can the changes be tested if applicable.