### PR TITLE
client: Add mouse hover on post & profile 

### DIFF
--- a/client/src/components/Posting.tsx
+++ b/client/src/components/Posting.tsx
@@ -18,7 +18,21 @@ const Posting = (props: { post: Post }) => {
   const longitude = props.post.longitude;
 
   return (
-    <Box maxW="sm" borderWidth="1px" margin="10px" borderRadius="lg" overflow="hidden">
+    <Box
+      maxW="sm"
+      borderWidth="1px"
+      margin="10px"
+      borderRadius="lg"
+      overflow="hidden"
+      cursor="pointer"
+      onClick={() =>
+        navigate(`/posting/${props.post.id}`, {
+          state: {
+            Post: props.post,
+          },
+        })
+      }
+    >
       <Box position="relative" my={3}>
         <Box
           maxW="sm"
@@ -32,13 +46,6 @@ const Posting = (props: { post: Post }) => {
             className="profile-img"
             src={thumbnailImage}
             alt={`Thumbnail for ${props.post.title}`}
-            onClick={() =>
-              navigate(`/posting/${props.post.id}`, {
-                state: {
-                  Post: props.post,
-                },
-              })
-            }
             opacity={1}
             transition="0.5s ease"
           />

--- a/client/src/components/nav/Navbar.tsx
+++ b/client/src/components/nav/Navbar.tsx
@@ -76,7 +76,12 @@ const Navbar = () => {
           </HStack>
         </HStack>
         <HStack as={"nav"} spacing={4} display={{ base: "none", lg: "flex" }}>
-          <Avatar onClick={openProfile} name={user?.displayName} src={avatarUrl} cursor="pointer" />
+          <Avatar
+            onClick={openProfile}
+            name={user?.displayName}
+            src={avatarUrl}
+            cursor={user ? "pointer" : "default"}
+          />
           <IconButton
             onClick={toggleColorMode}
             size={"md"}

--- a/client/src/components/nav/Navbar.tsx
+++ b/client/src/components/nav/Navbar.tsx
@@ -76,7 +76,7 @@ const Navbar = () => {
           </HStack>
         </HStack>
         <HStack as={"nav"} spacing={4} display={{ base: "none", lg: "flex" }}>
-          <Avatar onClick={openProfile} name={user?.displayName} src={avatarUrl} />
+          <Avatar onClick={openProfile} name={user?.displayName} src={avatarUrl} cursor="pointer" />
           <IconButton
             onClick={toggleColorMode}
             size={"md"}


### PR DESCRIPTION
## Description
Made the mouse change to 'pointer' made when hovering over a post and their profile picture. 
Clicking anywhere on a posting takes you to that posting, unlike before where you had to click the picture

### Type of change
- [ ] Backend (`api/`)
- [x] Frontend (`client/`)
- [ ] General
